### PR TITLE
support HT8xxV2 firmware by skipping the first 256 bytes of the file

### DIFF
--- a/SuperUser/GSSU.py
+++ b/SuperUser/GSSU.py
@@ -9,6 +9,11 @@ def gsresponse(password, challenge):
     res = hashlib.md5(key.encode('ascii')).digest()[:8]
     return binascii.hexlify(res).decode("ascii")
 
+def gsresponsev2(password, challenge):
+    key = "grAndSTreamTX20hT818V2FzC2M0AINT:"+challenge+":"+password+"\n"
+    res = hashlib.sha256(key.encode('ascii')).digest()
+    return binascii.hexlify(res).decode("ascii")[16:16+32]
+
 if __name__ == "__main__":
     print("Grandstream Super User by BigNerd95\n")
     if len(sys.argv) == 3:
@@ -16,6 +21,8 @@ if __name__ == "__main__":
         challenge = sys.argv[2]
         response = gsresponse(password, challenge)
         print("Response: " + response)
+        responsev2 = gsresponsev2(password, challenge)
+        print("Response HT8XXV2: " + responsev2)
     else:
         print("Usage: " + sys.argv[0] + " ADMIN_PASSWORD CHALLENGE")
         print("\nLogin via ssh in Grandstream device")

--- a/SuperUser/README.md
+++ b/SuperUser/README.md
@@ -1,4 +1,7 @@
 # GrandStream Super User
+
+## HT802 and similar
+
 - Connect to ssh and login with admin account
 - Run command `gssu`
 - Copy the challenge
@@ -23,6 +26,31 @@ conf             lang             sbin             var
 core             lib              sys
 country_profile  oem              test
 # 
+```
+
+## HT802V2 and similar
+
+- Connect as `root` via SSH. (Only works if you've sneaked in your key into `/.ssh/authorized_keys` somehow!)
+- Dropbear will automatically launch `gssu` for `root`
+- Copy the challenge and the PN
+- Run `python3 GSSU.py PN CHALLENGE`
+- Copy the response and paste it in the ssh shell
+- Enjoy your root shell ;-)
+
+Example:
+```
+% ./GSSU.py 9610001234A e00288708f0597ae1ebb169ad3e9cc53
+Grandstream Super User by BigNerd95
+
+Response: 97af1fd5a3f3ab48
+Response HT8XXV2: 8326356c77596b780cb0342d6d4b32db
+
+% ssh root@192.168.1.100
+PN: 9610001234A
+Challenge: e00288708f0597ae1ebb169ad3e9cc53
+Response:
+/ # uname -a
+Linux HT8XXV2 4.4.143 #108 SMP PREEMPT Mon May 13 18:12:49 CST 2024 armv7l GNU/Linux
 ```
 
 # Direct root shell (run time patch)


### PR DESCRIPTION
HT8xxV2 firmware has 256 bytes "stuff" before GS_MAGIC, and skipping those (and setting GS_NUM_FILES to 16) allows the files to be properly identified. extraction/patching doesn't work yet, but it's something.

also allows selecting GXP16XX using --mode instead of patching GS_NUM_FILES manually